### PR TITLE
Loading a stream

### DIFF
--- a/subprocess.hpp
+++ b/subprocess.hpp
@@ -626,7 +626,7 @@ namespace util
     int status = 0;
     int ret = -1;
     while (1) {
-      ret = waitpid(pid, &status, WNOHANG);
+      ret = waitpid(pid, &status, 0);
       if (ret == -1) break;
       if (ret == 0) continue;
       return std::make_pair(ret, status);


### PR DESCRIPTION
While waiting, the thread is loaded to 100% due to an infinite loop while(1). Why use the WNOHANG flag if we still must not break the loop until the child process terminates? It fixed this bag. Tested on running the linux program "sleep" ($ sleep 60). 